### PR TITLE
Refactor función checkForMatch

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -44,31 +44,30 @@ function dragDrop() {
 function checkForMatch(selected, dropTarget) {
   switch (selected) {
     case 'e1':
-      return dropTarget === 's1' ? true : false;
+      return dropTarget === 's1';
 
     case 'e2':
-      return dropTarget === 's2' ? true : false;
+      return dropTarget === 's2';
 
     case 'e3':
-      return dropTarget === 's3' ? true : false;
+      return dropTarget === 's3';
 
     case 'e4':
-      return dropTarget === 's4' ? true : false;
+      return dropTarget === 's4';
 
     case 'b1':
-      return dropTarget === 'a1' ? true : false;
+      return dropTarget === 'a1';
 
     case 'b2':
-      return dropTarget === 'a2' ? true : false;
+      return dropTarget === 'a2';
 
     case 'b3':
-      return dropTarget === 'a3' ? true : false;
+      return dropTarget === 'a3';
 
     case 'b4':
-      return dropTarget === 'a4' ? true : false;
-    default:
-      return false;
+      return dropTarget === 'a4';
   }
+  return false;
 }
 
 


### PR DESCRIPTION
Si una condición puede ser verdadero o falso se puede retornar directamente; los operadores removidos dicen "if true, true, if false, false", lo cual es redundante. De hecho, es muy raro tener que utilizar los valores literales `true` y `false`. La función se puede escribir como un único retorno:
```javascript
const checkForMatch = (selected, dropTarget) => (
  selected == 'e1' && dropTarget === 's1' ||
  selected == 'e2' && dropTarget === 's2' ||
  selected == 'e3' && dropTarget === 's3' ||
  selected == 'e4' && dropTarget === 's4' ||
  selected == 'b1' && dropTarget === 'a1' ||
  selected == 'b2' && dropTarget === 'a2' ||
  selected == 'b3' && dropTarget === 'a3' ||
  selected == 'b4' && dropTarget === 'a4'
);
```
Lo que equivale en la sintaxis antigua de declaración de funciones:
```javascript
function checkForMatch(selected, dropTarget) {
  return (
    selected == 'e1' && dropTarget === 's1' ||
    selected == 'e2' && dropTarget === 's2' ||
    selected == 'e3' && dropTarget === 's3' ||
    selected == 'e4' && dropTarget === 's4' ||
    selected == 'b1' && dropTarget === 'a1' ||
    selected == 'b2' && dropTarget === 'a2' ||
    selected == 'b3' && dropTarget === 'a3' ||
    selected == 'b4' && dropTarget === 'a4'
  );
}
```